### PR TITLE
[PR](CI): Added basic Ci to push to epitech repository

### DIFF
--- a/.github/workflows/push_to_epi.yml
+++ b/.github/workflows/push_to_epi.yml
@@ -64,6 +64,13 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
+      - name: Validate SSH key
+        run: |
+          if [ -z "${{ secrets.GIT_SSH_PRIVATE_KEY }}" ]; then
+            echo "Error: GIT_SSH_PRIVATE_KEY secret is not configured"
+            exit 1
+          fi
+
       - name: Push to mirror repository
         uses: pixta-dev/repository-mirroring-action@v1.1.1
         with:


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate repository mirroring and prevent redundant jobs when running in the mirror repository. The workflow includes logic to detect the repository context and only push to the mirror when appropriate.

**Workflow automation and mirroring:**

* Added a new workflow file `.github/workflows/push_to_epi.yml` to automate pushing changes to a mirror repository and to prevent running jobs in the mirror itself.
* Implemented a job (`cancel-if-mirror`) that checks if the current repository is the mirror and sets an output to control subsequent workflow execution.
* Added a job (`push_to_mirror`) that pushes to the mirror repository only when on the `main` branch, a push event occurs, and the repository is not the mirror.