### PR TITLE
[PR](Network): Added TCP echo server and client to demonstrate head-of-line blocking

### DIFF
--- a/PoC/PoC_Network_Protocol/CMakeLists.txt
+++ b/PoC/PoC_Network_Protocol/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.16)
+project(TcpTest)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_executable(tcptest TcpTest.cpp)
+
+find_package(Threads REQUIRED)
+target_link_libraries(tcptest Threads::Threads)
+
+if(MSVC)
+    target_compile_options(tcptest PRIVATE /W4)
+else()
+    target_compile_options(tcptest PRIVATE -Wall -Wextra -Wpedantic)
+endif()

--- a/PoC/PoC_Network_Protocol/README.md
+++ b/PoC/PoC_Network_Protocol/README.md
@@ -1,0 +1,103 @@
+# TCP Head-of-Line Blocking Demonstration
+
+This PoC demonstrates the head-of-line blocking issue with TCP, which is critical for understanding why UDP is preferred for real-time multiplayer games like R-Type.
+
+## What is Head-of-Line Blocking?
+
+In TCP, packets must be delivered in order. If one packet is lost or delayed, all subsequent packets are held in a queue until the missing packet arrives. This can cause significant latency spikes in real-time applications.
+
+## How to Run the Test
+
+### Prerequisites
+
+- CMake 3.16+
+- C++17 compiler
+- Linux/macOS (or adjust for Windows)
+
+### Build
+
+```bash
+mkdir build
+cd build
+cmake ..
+make
+```
+
+### Run Server
+
+```bash
+./tcptest server
+```
+
+### Run Client (Normal Operation)
+
+In another terminal:
+
+```bash
+./tcptest client
+```
+
+This will send 10 packets and show normal TCP behavior.
+
+### Run Client (Simulate Packet Drop)
+
+```bash
+./tcptest client simulate_drop
+```
+
+This simulates dropping packet 5, demonstrating head-of-line blocking.
+
+## Expected Behavior
+
+### Normal Operation
+
+- All 10 packets are sent and received quickly
+- Responses come back in order
+- No significant delays
+
+### With Packet Drop Simulation
+
+**Current Implementation:**
+
+- Packets 1-4 are processed normally
+- Packet 5 is skipped (not sent by client)
+- Packets 6-10 are sent and received normally (no blocking observed)
+- Server renumbers received packets sequentially
+
+**Limitation:**
+
+The current simulation doesn't trigger actual TCP retransmission because TCP doesn't know packet 5 is missing - the sequence continues normally.
+
+**For True Head-of-Line Blocking:**
+
+Network-level packet dropping would be needed to trigger TCP's retransmission mechanism and demonstrate the blocking effect.
+
+## Why This Matters for R-Type
+
+In a fast-paced shooter like R-Type:
+
+- Player inputs must be processed immediately (<50ms latency)
+- Head-of-line blocking can cause 200ms+ delays
+- This makes the game feel unresponsive and unplayable
+- UDP avoids this by allowing out-of-order delivery
+
+## Test Results
+
+### Normal TCP (no drops)
+
+- Average latency: ~140μs per packet
+- All packets delivered in order
+- Total test duration: 502ms
+
+### TCP with simulated drop
+
+- Packet 5 skipped by client
+- Server received packets 6-10 as packets 5-9
+- No head-of-line blocking observed (simulation limitation)
+- Total test duration: 452ms
+
+*Note: The current simulation skips sending packet 5 but doesn't trigger actual TCP retransmission. For true head-of-line blocking demonstration, network-level packet dropping would be needed.*
+
+## Conclusion
+
+TCP's reliability comes at the cost of potential latency spikes due to head-of-line blocking, making it unsuitable for real-time game input handling. UDP with custom reliability mechanisms is the better choice for R-Type's core gameplay loop.

--- a/PoC/PoC_Network_Protocol/TcpTest.cpp
+++ b/PoC/PoC_Network_Protocol/TcpTest.cpp
@@ -1,0 +1,223 @@
+/*
+** EPITECH PROJECT, 2025
+** Rtype
+** File description:
+** TcpTest - TCP Echo Server to demonstrate Head-of-Line Blocking
+*/
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <cstdio>
+
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+#include <chrono>
+#include <cstring>
+
+class TcpEchoServer {
+private:
+    int server_fd;
+    struct sockaddr_in address;
+    int addrlen = sizeof(address);
+    bool running = false;
+
+public:
+    explicit TcpEchoServer(int port) {
+        if ((server_fd = socket(AF_INET, SOCK_STREAM, 0)) == 0) {
+            perror("socket failed");
+            exit(EXIT_FAILURE);
+        }
+
+        int opt = 1;
+        if (setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR | SO_REUSEPORT, &opt, sizeof(opt))) {
+            perror("setsockopt");
+            exit(EXIT_FAILURE);
+        }
+
+        address.sin_family = AF_INET;
+        address.sin_addr.s_addr = INADDR_ANY;
+        address.sin_port = htons(port);
+
+        if (bind(server_fd, (struct sockaddr *)&address, sizeof(address)) < 0) {
+            perror("bind failed");
+            exit(EXIT_FAILURE);
+        }
+
+        if (listen(server_fd, 3) < 0) {
+            perror("listen");
+            exit(EXIT_FAILURE);
+        }
+
+        std::cout << "TCP Echo Server listening on port " << port << std::endl;
+    }
+
+    ~TcpEchoServer() {
+        if (server_fd >= 0) {
+            close(server_fd);
+        }
+    }
+
+    void start() {
+        running = true;
+        std::cout << "Server started. Waiting for connections..." << std::endl;
+
+        while (running) {
+            int client_socket;
+            if ((client_socket = accept(server_fd, (struct sockaddr *)&address, reinterpret_cast<socklen_t*>(&addrlen))) < 0) {
+                if (running) {
+                    perror("accept");
+                }
+                continue;
+            }
+
+            std::cout << "New client connected" << std::endl;
+            std::thread client_thread(&TcpEchoServer::handleClient, this, client_socket);
+            client_thread.detach();
+        }
+    }
+
+    void stop() {
+        running = false;
+        close(server_fd);
+        server_fd = -1;
+    }
+
+private:
+    void handleClient(int client_socket) {
+        char buffer[1024] = {0};
+        int packet_count = 0;
+
+        while (running) {
+            ssize_t valread = read(client_socket, buffer, 1024);
+            if (valread <= 0) {
+                if (valread < 0) {
+                    perror("read");
+                }
+                break;
+            }
+
+            packet_count++;
+            std::string received_data(buffer, valread);
+
+            std::string response = "Echo[" + std::to_string(packet_count) + "]: " + received_data;
+            send(client_socket, response.c_str(), response.length(), 0);
+
+            std::cout << "Processed packet " << packet_count << ": " << received_data.substr(0, 50) << "..." << std::endl;
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+
+        close(client_socket);
+        std::cout << "Client disconnected" << std::endl;
+    }
+};
+
+class TcpEchoClient {
+private:
+    int sock;
+    struct sockaddr_in serv_addr;
+
+public:
+    TcpEchoClient(const char* server_ip, int port) {
+        if ((sock = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+            perror("Socket creation error");
+            exit(EXIT_FAILURE);
+        }
+
+        serv_addr.sin_family = AF_INET;
+        serv_addr.sin_port = htons(port);
+
+        if (inet_pton(AF_INET, server_ip, &serv_addr.sin_addr) <= 0) {
+            perror("Invalid address");
+            exit(EXIT_FAILURE);
+        }
+
+        if (connect(sock, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0) {
+            perror("Connection Failed");
+            exit(EXIT_FAILURE);
+        }
+
+        std::cout << "Connected to server" << std::endl;
+    }
+
+    ~TcpEchoClient() {
+        if (sock >= 0) {
+            close(sock);
+        }
+    }
+
+    void sendPackets(int num_packets, bool simulate_drop = false) {
+        auto start_time = std::chrono::high_resolution_clock::now();
+
+        for (int i = 1; i <= num_packets; ++i) {
+            auto packet_start = std::chrono::high_resolution_clock::now();
+
+            std::string message = "Packet " + std::to_string(i) + " - " + std::string(100, 'X');
+
+            if (simulate_drop && i == 5) {
+                std::cout << "SIMULATING DROP: Skipping packet " << i << " at "
+                          << std::chrono::duration_cast<std::chrono::milliseconds>(
+                                 packet_start - start_time).count() << "ms" << std::endl;
+                continue;
+            }
+
+            send(sock, message.c_str(), message.length(), 0);
+
+            char buffer[1024] = {0};
+            ssize_t valread = read(sock, buffer, 1024);
+
+            auto packet_end = std::chrono::high_resolution_clock::now();
+            auto packet_latency = std::chrono::duration_cast<std::chrono::microseconds>(packet_end - packet_start);
+
+            if (valread > 0) {
+                std::cout << "Packet " << i << " - Latency: " << packet_latency.count() << "μs - "
+                          << std::string(buffer, valread).substr(0, 60) << "..." << std::endl;
+            } else {
+                std::cout << "Packet " << i << " - TIMEOUT/ERROR after " << packet_latency.count() << "μs" << std::endl;
+            }
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        }
+
+        auto end_time = std::chrono::high_resolution_clock::now();
+        auto total_duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
+        std::cout << "\nTotal test duration: " << total_duration.count() << "ms" << std::endl;
+    }
+};
+
+int main(int argc, char const *argv[]) {
+    if (argc < 2) {
+        std::cout << "Usage: " << argv[0] << " <server|client> [simulate_drop]" << std::endl;
+        std::cout << "  server: Run as TCP echo server" << std::endl;
+        std::cout << "  client: Run as TCP echo client (connects to localhost:8080)" << std::endl;
+        std::cout << "  simulate_drop: For client mode, simulate dropping packet 5" << std::endl;
+        return 1;
+    }
+
+    std::string mode = argv[1];
+    bool simulate_drop = (argc > 2 && std::string(argv[2]) == "simulate_drop");
+
+    if (mode == "server") {
+        TcpEchoServer server(8080);
+        server.start();
+    } else if (mode == "client") {
+        TcpEchoClient client("127.0.0.1", 8080);
+        std::cout << "Sending 10 packets..." << std::endl;
+        if (simulate_drop) {
+            std::cout << "Will simulate dropping packet 5 to demonstrate head-of-line blocking" << std::endl;
+        }
+        client.sendPackets(10, simulate_drop);
+        std::cout << "Test completed" << std::endl;
+    } else {
+        std::cout << "Invalid mode. Use 'server' or 'client'" << std::endl;
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This pull request introduces a new proof-of-concept (PoC) project that demonstrates TCP head-of-line blocking, which is relevant for understanding network protocol choices in real-time multiplayer games like R-Type. The changes add a CMake build configuration, a detailed README with instructions and context, and a complete C++ implementation of a TCP echo server and client for testing and demonstration.

The most important changes are:

### New TCP Head-of-Line Blocking Demonstration

* Added a new C++ program `TcpTest.cpp` implementing both a TCP echo server and client. The client can simulate packet drops to illustrate TCP's head-of-line blocking behavior, with detailed logging and timing for each packet.

### Build System

* Introduced a `CMakeLists.txt` file to configure building the demonstration with CMake, setting C++17 as the standard and supporting cross-platform warnings.

### Documentation

* Added a comprehensive `README.md` explaining TCP head-of-line blocking, how to build and run the demo, expected behaviors, limitations of the simulation, and its implications for real-time games like R-Type.

Closes #39 