### PR TITLE
[PR](Releases): Added release ci automatic and manual

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,15 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Check branch for manual release
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ "${{ github.ref_name }}" != "main" ]; then
+            echo "❌ Manual releases can only be triggered from the main branch"
+            echo "Current branch: ${{ github.ref_name }}"
+            exit 1
+          fi
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -163,5 +172,3 @@ jobs:
             release-assets/rtype_client.exe
             release-assets/rtype_server
             release-assets/rtype_server.exe
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the release process for the project. The workflow handles version calculation, downloads build artifacts for multiple platforms, prepares release assets, and creates a GitHub release with the appropriate files and metadata.

Key changes in `.github/workflows/release.yml`:

**Release Automation:**

* Added a new workflow (`release.yml`) that triggers on pushes to `main` and `dev` branches, as well as via manual dispatch with a selectable release type.
* Implements automated versioning logic based on the branch or manual trigger, incrementing the major, minor, or patch version as appropriate.

**Artifact Management:**

* Downloads client and server build artifacts for both Linux and Windows from the CI workflow, and prepares them as release assets.

**Release Creation:**

* Creates a GitHub release with auto-generated release notes, attaching the prepared binaries and marking pre-releases when appropriate.