### PR TITLE
[PR](CIRelease): update workflow to support context determination and ar…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,10 @@
 name: 🚀 R-Type Release
 
 on:
-  push:
+  workflow_run:
+    workflows: ["R-Type Action"]
+    types:
+      - completed
     branches:
       - main
       - dev
@@ -20,6 +23,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: write
       pull-requests: write
@@ -34,9 +38,23 @@ jobs:
             exit 1
           fi
 
+      - name: Determine context
+        id: ctx
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_run" ]; then
+            echo "branch=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
+            echo "sha=${{ github.event.workflow_run.head_sha }}" >> $GITHUB_OUTPUT
+            echo "run_id=${{ github.event.workflow_run.id }}" >> $GITHUB_OUTPUT
+          else
+            echo "branch=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+            echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
+            echo "run_id=" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          ref: ${{ steps.ctx.outputs.sha }}
           fetch-depth: 0
           fetch-tags: true
 
@@ -60,7 +78,7 @@ jobs:
         id: version
         run: |
           LATEST_TAG="${{ steps.latest_release.outputs.latest_tag }}"
-          BRANCH="${{ github.ref_name }}"
+          BRANCH="${{ steps.ctx.outputs.branch }}"
           EVENT_NAME="${{ github.event_name }}"
 
           VERSION="${LATEST_TAG#v}"
@@ -101,7 +119,8 @@ jobs:
         uses: dawidd6/action-download-artifact@v6
         with:
           workflow: ci.yml
-          branch: ${{ github.ref_name }}
+          run_id: ${{ steps.ctx.outputs.run_id }}
+          branch: ${{ steps.ctx.outputs.branch }}
           name: r-type_client-ubuntu-latest
           path: ./artifacts/linux-client
 
@@ -109,7 +128,8 @@ jobs:
         uses: dawidd6/action-download-artifact@v6
         with:
           workflow: ci.yml
-          branch: ${{ github.ref_name }}
+          run_id: ${{ steps.ctx.outputs.run_id }}
+          branch: ${{ steps.ctx.outputs.branch }}
           name: r-type_client-windows-latest
           path: ./artifacts/windows-client
 
@@ -117,7 +137,8 @@ jobs:
         uses: dawidd6/action-download-artifact@v6
         with:
           workflow: ci.yml
-          branch: ${{ github.ref_name }}
+          run_id: ${{ steps.ctx.outputs.run_id }}
+          branch: ${{ steps.ctx.outputs.branch }}
           name: r-type_server-ubuntu-latest
           path: ./artifacts/linux-server
 
@@ -125,7 +146,8 @@ jobs:
         uses: dawidd6/action-download-artifact@v6
         with:
           workflow: ci.yml
-          branch: ${{ github.ref_name }}
+          run_id: ${{ steps.ctx.outputs.run_id }}
+          branch: ${{ steps.ctx.outputs.branch }}
           name: r-type_server-windows-latest
           path: ./artifacts/windows-server
 


### PR DESCRIPTION
This pull request updates the `release.yml` GitHub Actions workflow to improve how releases are triggered and how artifacts are downloaded. The main focus is on making the release process more robust and compatible with both manual and automated triggers, especially following the completion of the "R-Type Action" workflow.

Workflow trigger and context handling:

* Changed the workflow trigger from a direct `push` to a `workflow_run` that listens for the completion of the "R-Type Action" workflow, ensuring releases only happen after successful runs.
* Added a conditional to only run the release job if triggered manually or if the previous workflow run concluded successfully.
* Introduced a new "Determine context" step to correctly set the branch, commit SHA, and workflow run ID based on how the workflow was triggered, improving compatibility with both manual and automated triggers.

Artifact download improvements:

* Updated artifact download steps to use the correct `run_id` and branch from the determined context, ensuring the right artifacts are fetched regardless of trigger type.

Variable usage improvements:

* Updated variable references throughout the workflow to use the new context outputs, making the workflow more reliable and reducing the risk of mismatched versions or branches.…tifact downloads from workflow runs